### PR TITLE
fix(pingdom): implement cut off for too long tags

### DIFF
--- a/internal/service/providers/pingdom_test.go
+++ b/internal/service/providers/pingdom_test.go
@@ -26,7 +26,7 @@ func TestAgainstREALPingdomAPI(t *testing.T) {
 				"uptime.pdok.nl/id":                                     "3w2e9d804b2cd6bf18b8c0a6e1c04e46ac62b98c",
 				"uptime.pdok.nl/name":                                   "UptimeOperatorPingdomTestCheck",
 				"uptime.pdok.nl/url":                                    "https://service.pdok.nl/cbs/landuse/wfs/v1_0?request=GetCapabilities&service=WFS",
-				"uptime.pdok.nl/tags":                                   "tag1, tag2",
+				"uptime.pdok.nl/tags":                                   "tag1, tag2, TooLongTagOvEtj8xOzZmGPJNf5ZcGikHzTjAG55xvcWVymItA0O8Us9tq6fEAfRYeN6AODj2gwRRi5l",
 				"uptime.pdok.nl/request-headers":                        "key1:value1, key2:value2",
 				"uptime.pdok.nl/response-check-for-string-contains":     "bla",
 				"uptime.pdok.nl/response-check-for-string-not-contains": "",


### PR DESCRIPTION
# Description

Cut off tags above 64 chars

## Type of change

- Minor change

# Checklist:

- [ ] I've double-checked the code in this PR myself
- [ ] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [ ] The code is readable, comments are added that explain hard or non-obvious parts.
- [ ] I've expanded/improved the (unit) tests, when applicable
- [ ] I've run (unit) tests that prove my solution works
- [ ] There's no sensitive information like credentials in my PR