### PR TITLE
feat(slack) add rate limiting

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/slack-go/slack v0.13.0
 	github.com/stretchr/testify v1.9.0
 	github.com/traefik/traefik/v2 v2.11.5
+	golang.org/x/time v0.5.0
 	golang.org/x/tools v0.22.0
 	k8s.io/apimachinery v0.30.2
 	k8s.io/client-go v0.30.2
@@ -72,7 +73,6 @@ require (
 	golang.org/x/sys v0.21.0 // indirect
 	golang.org/x/term v0.21.0 // indirect
 	golang.org/x/text v0.16.0 // indirect
-	golang.org/x/time v0.5.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/internal/service/slack.go
+++ b/internal/service/slack.go
@@ -5,23 +5,38 @@ import (
 
 	"github.com/PDOK/uptime-operator/internal/model"
 	"github.com/slack-go/slack"
+	"golang.org/x/time/rate"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	nrOfMessagesPerSec   = 1
+	nrOfMessagesPerBurst = 10
 )
 
 type Slack struct {
 	webhookURL string
 	channelID  string
+
+	rateLimit *rate.Limiter
 }
 
 func NewSlack(webhookURL, channelID string) *Slack {
 	return &Slack{
 		webhookURL: webhookURL,
 		channelID:  channelID,
+
+		// see https://api.slack.com/apis/rate-limits
+		rateLimit: rate.NewLimiter(nrOfMessagesPerSec, nrOfMessagesPerBurst),
 	}
 }
 
 func (s *Slack) Send(ctx context.Context, message string) {
-	err := slack.PostWebhook(s.webhookURL, &slack.WebhookMessage{
+	err := s.rateLimit.Wait(ctx)
+	if err != nil {
+		log.FromContext(ctx).Error(err, "failed waiting for slack rate limit")
+	}
+	err = slack.PostWebhook(s.webhookURL, &slack.WebhookMessage{
 		Channel:   s.channelID,
 		Text:      message,
 		Username:  model.OperatorName,


### PR DESCRIPTION
# Description

Avoid messages like:

```
"error": "slack rate limit exceeded, retry after 1s"}
2024-06-24 18:25:39.149Z github.com/PDOK/uptime-operator/internal/service.(*Slack).Send
2024-06-24 18:25:39.149Z        /workspace/internal/service/slack.go:31
2024-06-24 18:25:39.149Z github.com/PDOK/uptime-operator/internal/service.(*UptimeCheckService).logMutation
2024-06-24 18:25:39.149Z        /workspace/internal/service/service.go:135
2024-06-24 18:25:39.149Z github.com/PDOK/uptime-operator/internal/service.(*UptimeCheckService).Mutate
2024-06-24 18:25:39.149Z        /workspace/internal/service/service.go:79
2024-06-24 18:25:39.149Z github.com/PDOK/uptime-operator/internal/controller.(*IngressRouteReconciler).Reconcile```
```

## Type of change

- Improvement of existing feature

# Checklist:

- [x] I've double-checked the code in this PR myself
- [ ] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [ ] The code is readable, comments are added that explain hard or non-obvious parts.
- [ ] I've expanded/improved the (unit) tests, when applicable
- [ ] I've run (unit) tests that prove my solution works
- [ ] There's no sensitive information like credentials in my PR