### PR TITLE
chore: drop support for legacy traefik.containo.us CRDs

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -10,11 +10,6 @@ repo: github.com/PDOK/uptime-operator
 resources:
 - controller: true
   domain: pdok.nl
-  group: traefik.containo.us
-  kind: IngressRoute
-  version: v1alpha1
-- controller: true
-  domain: pdok.nl
   group: traefik.io
   kind: IngressRoute
   version: v1alpha1

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Submit a PR when you wish to add another provider!
 Traefik `IngressRoute` resources should be annotated in order to successfully register an uptime check. For example:
 
 ```yaml
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
   name: my-sweet-route
@@ -36,7 +36,7 @@ metadata:
 
 The `id`, `name` and `url` annotations are mandatory, the rest is optional.
 
-Both `traefik.containo.us/v1alpha1` as well as `traefik.io/v1alpha1` resources are supported.
+Only `traefik.io/v1alpha1` resources are supported (not the legacy `traefik.containo.us`).
 
 ### Ignoring routes
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -42,7 +42,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	"github.com/PDOK/uptime-operator/internal/controller"
-	traefikcontainous "github.com/traefik/traefik/v2/pkg/provider/kubernetes/crd/traefikcontainous/v1alpha1"
 	traefikio "github.com/traefik/traefik/v2/pkg/provider/kubernetes/crd/traefikio/v1alpha1"
 	//+kubebuilder:scaffold:imports
 )
@@ -55,7 +54,6 @@ var (
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
-	utilruntime.Must(traefikcontainous.AddToScheme(scheme))
 	utilruntime.Must(traefikio.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
 }

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -5,20 +5,6 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
-  - traefik.containo.us
-  resources:
-  - ingressroutes
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - traefik.containo.us
-  resources:
-  - ingressroutes/finalizers
-  verbs:
-  - update
-- apiGroups:
   - traefik.io
   resources:
   - ingressroutes

--- a/internal/controller/ingressroute_controller_test.go
+++ b/internal/controller/ingressroute_controller_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/PDOK/uptime-operator/internal/service"
 	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo bdd
 	. "github.com/onsi/gomega"    //nolint:revive // gingko bdd
-	traefikcontainous "github.com/traefik/traefik/v2/pkg/provider/kubernetes/crd/traefikcontainous/v1alpha1"
+	traefikio "github.com/traefik/traefik/v2/pkg/provider/kubernetes/crd/traefikio/v1alpha1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -64,7 +64,7 @@ func (m *testUptimeProvider) DeleteCheck(_ context.Context, check m.UptimeCheck)
 	return nil
 }
 
-var ingressRouteWithUptimeCheck = &traefikcontainous.IngressRoute{
+var ingressRouteWithUptimeCheck = &traefikio.IngressRoute{
 	TypeMeta: v1.TypeMeta{},
 	ObjectMeta: v1.ObjectMeta{
 		Name:      testIngress,
@@ -76,14 +76,14 @@ var ingressRouteWithUptimeCheck = &traefikcontainous.IngressRoute{
 			m.AnnotationName: "Test uptime check",
 		},
 	},
-	Spec: traefikcontainous.IngressRouteSpec{
-		Routes: []traefikcontainous.Route{
+	Spec: traefikio.IngressRouteSpec{
+		Routes: []traefikio.Route{
 			{
 				Kind:  "Rule",
 				Match: "Host(`localhost`)",
-				Services: []traefikcontainous.Service{
+				Services: []traefikio.Service{
 					{
-						LoadBalancerSpec: traefikcontainous.LoadBalancerSpec{
+						LoadBalancerSpec: traefikio.LoadBalancerSpec{
 							Name: "test",
 						},
 					},
@@ -111,7 +111,7 @@ var _ = Describe("IngressRoute Controller", func() {
 			}
 
 			By("Creating an IngressRoute")
-			newIngressRoute := &traefikcontainous.IngressRoute{}
+			newIngressRoute := &traefikio.IngressRoute{}
 			err := k8sClient.Get(ctx, typeNamespacedName, newIngressRoute)
 			if err != nil {
 				if k8serrors.IsNotFound(err) {
@@ -135,7 +135,7 @@ var _ = Describe("IngressRoute Controller", func() {
 			}))
 
 			By("Fetching and updating IngressRoute (adding extra uptime annotation)")
-			fetchedIngressRoute := &traefikcontainous.IngressRoute{}
+			fetchedIngressRoute := &traefikio.IngressRoute{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, typeNamespacedName, fetchedIngressRoute)
 				return err == nil
@@ -182,7 +182,7 @@ var _ = Describe("IngressRoute Controller", func() {
 			}))
 
 			By("Delete IngressRoute")
-			fetchedIngressRoute := &traefikcontainous.IngressRoute{}
+			fetchedIngressRoute := &traefikio.IngressRoute{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, typeNamespacedName, fetchedIngressRoute)
 				return err == nil

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -37,7 +37,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo bdd
 	. "github.com/onsi/gomega"    //nolint:revive // ginkgo bdd
-	traefikcontainous "github.com/traefik/traefik/v2/pkg/provider/kubernetes/crd/traefikcontainous/v1alpha1"
 	traefikio "github.com/traefik/traefik/v2/pkg/provider/kubernetes/crd/traefikio/v1alpha1"
 
 	"k8s.io/client-go/kubernetes/scheme"
@@ -90,9 +89,6 @@ var _ = BeforeSuite(func() {
 	cfg, err = testEnv.Start()
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
-
-	err = traefikcontainous.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
 
 	err = traefikio.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Since these aren't supported anymore by Traefik v3.

## Type of change

- Breaking change

# Checklist:

- [ ] I've double-checked the code in this PR myself
- [ ] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [ ] The code is readable, comments are added that explain hard or non-obvious parts.
- [ ] I've expanded/improved the (unit) tests, when applicable
- [ ] I've run (unit) tests that prove my solution works
- [ ] There's no sensitive information like credentials in my PR