### PR TITLE
Pdok 18978/fix duplicate tags

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -96,6 +96,10 @@ linters:
       - std-error-handling
     rules:
       - linters:
+          - revive
+        text: "var-naming: avoid meaningless package names"
+        path: internal/util/
+      - linters:
           - bodyclose
           - dogsled
           - dupl

--- a/internal/model/check.go
+++ b/internal/model/check.go
@@ -58,7 +58,7 @@ func NewUptimeCheck(ingressName string, annotations map[string]string) (*UptimeC
 		ID:                id,
 		Name:              name,
 		URL:               url,
-		Tags:              stringToSlice(annotations[AnnotationTags]),
+		Tags:              parseTags(annotations[AnnotationTags]),
 		Interval:          interval,
 		RequestHeaders:    kvStringToMap(annotations[AnnotationRequestHeaders]),
 		StringContains:    annotations[AnnotationStringContains],
@@ -99,14 +99,24 @@ func kvStringToMap(s string) map[string]string {
 	return result
 }
 
-func stringToSlice(s string) []string {
+func parseTags(s string) []string {
 	if s == "" {
 		return nil
 	}
+
+	seen := make(map[string]struct{})
 	var result []string
 	splits := strings.Split(s, ",")
 	for _, part := range splits {
-		result = append(result, strings.TrimSpace(part))
+		value := strings.TrimSpace(part)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
 	}
 	return result
 }

--- a/internal/model/check_test.go
+++ b/internal/model/check_test.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"slices"
 	"testing"
 )
 
@@ -9,6 +10,7 @@ func TestNewUptimeCheck(t *testing.T) {
 		name        string
 		ingressName string
 		annotations map[string]string
+		wantTags    []string
 		wantErr     bool
 	}{
 		{
@@ -23,7 +25,8 @@ func TestNewUptimeCheck(t *testing.T) {
 				"uptime.pdok.nl/response-check-for-string-contains":     "test string",
 				"uptime.pdok.nl/response-check-for-string-not-contains": "",
 			},
-			wantErr: false,
+			wantTags: []string{"tag1", "tag2", TagManagedBy},
+			wantErr:  false,
 		},
 		{
 			name:        "Missing ID annotation",
@@ -36,7 +39,8 @@ func TestNewUptimeCheck(t *testing.T) {
 				"uptime.pdok.nl/response-check-for-string-contains":     "test string",
 				"uptime.pdok.nl/response-check-for-string-not-contains": "",
 			},
-			wantErr: true,
+			wantTags: nil,
+			wantErr:  true,
 		},
 		{
 			name:        "Missing Name annotation",
@@ -49,7 +53,8 @@ func TestNewUptimeCheck(t *testing.T) {
 				"uptime.pdok.nl/response-check-for-string-contains":     "test string",
 				"uptime.pdok.nl/response-check-for-string-not-contains": "",
 			},
-			wantErr: true,
+			wantTags: nil,
+			wantErr:  true,
 		},
 		{
 			name:        "Missing URL annotation",
@@ -62,7 +67,8 @@ func TestNewUptimeCheck(t *testing.T) {
 				"uptime.pdok.nl/response-check-for-string-contains":     "test string",
 				"uptime.pdok.nl/response-check-for-string-not-contains": "",
 			},
-			wantErr: true,
+			wantTags: nil,
+			wantErr:  true,
 		},
 		{
 			name:        "Missing tags annotation",
@@ -75,7 +81,8 @@ func TestNewUptimeCheck(t *testing.T) {
 				"uptime.pdok.nl/response-check-for-string-contains":     "test string",
 				"uptime.pdok.nl/response-check-for-string-not-contains": "",
 			},
-			wantErr: false,
+			wantTags: []string{TagManagedBy},
+			wantErr:  false,
 		},
 		{
 			name:        "Missing request-headers annotation",
@@ -88,14 +95,33 @@ func TestNewUptimeCheck(t *testing.T) {
 				"uptime.pdok.nl/response-check-for-string-contains":     "test string",
 				"uptime.pdok.nl/response-check-for-string-not-contains": "",
 			},
-			wantErr: false,
+			wantTags: []string{"tag1", "tag2", TagManagedBy},
+			wantErr:  false,
+		},
+		{
+			name:        "Duplicate tags",
+			ingressName: "test-ingress",
+			annotations: map[string]string{
+				"uptime.pdok.nl/id":   "1234567890",
+				"uptime.pdok.nl/name": "Test Check",
+				"uptime.pdok.nl/url":  "https://pdok.example",
+				"uptime.pdok.nl/tags": "tag1, tag2, tag1, tag3, tag2, , tag3",
+			},
+			wantTags: []string{"tag1", "tag2", "tag3", TagManagedBy},
+			wantErr:  false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := NewUptimeCheck(tt.ingressName, tt.annotations)
+			check, err := NewUptimeCheck(tt.ingressName, tt.annotations)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("NewUptimeCheck() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr || tt.wantTags == nil {
+				return
+			}
+			if !slices.Equal(check.Tags, tt.wantTags) {
+				t.Errorf("NewUptimeCheck().Tags = %v, want %v", check.Tags, tt.wantTags)
 			}
 		})
 	}

--- a/internal/service/providers/betterstack/client.go
+++ b/internal/service/providers/betterstack/client.go
@@ -32,7 +32,7 @@ func (h Client) execRequest(req *http.Request, expectedStatus int) (*http.Respon
 	if resp.StatusCode != expectedStatus {
 		defer resp.Body.Close()
 		result, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("got status %d, expected %d. Body: %b", resp.StatusCode, expectedStatus, result)
+		return nil, fmt.Errorf("got status %d, expected %d. Body: %s", resp.StatusCode, expectedStatus, result)
 	}
 	return resp, nil // caller should close resp.Body!
 }

--- a/internal/util/flag.go
+++ b/internal/util/flag.go
@@ -1,4 +1,4 @@
-package util //nolint:revive
+package util
 
 import (
 	"strings"


### PR DESCRIPTION
# Description

- fix: handling of duplicate and empty tags: to fix errors when creating betterstack monitors
- fix: correct formatting in error message for response body. Log in string, not in bytes: for clear logs messages


## Type of change

- Bugfix

# Checklist:

- [x] I've double-checked the code in this PR myself
- [ ] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [x] The code is readable, comments are added that explain hard or non-obvious parts.
- [x] I've expanded/improved the (unit) tests, when applicable
- [x] I've run (unit) tests that prove my solution works
- [ ] There's no sensitive information like credentials in my PR